### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A growing repository with simple functions to improve integration of Gravity For
 #### [gravity-forms-bootstrap-styles.php](https://github.com/5t3ph/gravity-forms-snippets/blob/master/gravity-forms-bootstrap-styles.php)
 - Applies [Bootstrap classes](http://getbootstrap.com/css/#forms) to various fields.
 - Requires Bootstrap to be in use by the theme.
-- Using this function allows use of Gravity Forms default CSS in conjuction with Bootstrap (benefit for fields types such as Address).
+- Using this function allows use of Gravity Forms default CSS in conjunction with Bootstrap (benefit for fields types such as Address).
 
 #### [gravity-forms-style.css](https://github.com/5t3ph/gravity-forms-snippets/blob/master/gravity-forms-style.css)
 - A file of suggested CSS additions.


### PR DESCRIPTION
@5t3ph, I've corrected a typographical error in the documentation of the [gravity-forms-snippets](https://github.com/5t3ph/gravity-forms-snippets) project. Specifically, I've changed conjuction to conjunction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
